### PR TITLE
feat!: allow beta testers to access courses early

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-craft/frontend-app-learning-paths",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-craft/frontend-app-learning-paths",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-craft/frontend-app-learning-paths",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Frontend application template",
   "repository": {
     "type": "git",

--- a/src/learningpath/CourseCard.jsx
+++ b/src/learningpath/CourseCard.jsx
@@ -88,12 +88,16 @@ export const CourseCard = ({
   // Determine access text and override button text based on access dates.
   if (startDateObj && startDateObj > currentDate) {
     // Course will start in the future.
-    const startDateStr = startDateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const startDateStr = startDateObj.toLocaleString(undefined, {
+      month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+    });
     accessText = <>Access starts on <b>{startDateStr}</b></>;
     buttonText = 'Start';
     showStartButton = administrator;
   } else if (endDateObj) {
-    const endDateStr = endDateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const endDateStr = endDateObj.toLocaleString(undefined, {
+      month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+    });
     if (currentDate > endDateObj) {
       // Course has ended.
       accessText = <>Access ended on <b>{endDateStr}</b></>;

--- a/src/learningpath/CourseCard.jsx
+++ b/src/learningpath/CourseCard.jsx
@@ -34,6 +34,7 @@ export const CourseCard = ({
     hasOptionalCompletion,
     hasUnearnedOptionalCompletion,
     checkingEnrollment,
+    access,
   } = course;
 
   const { administrator } = getAuthenticatedUser();
@@ -76,7 +77,8 @@ export const CourseCard = ({
     buttonText = 'Loading...';
   }
 
-  const disableStartButton = !administrator && (checkingEnrollment || isEnrolledInLearningPath === false);
+  const hasStaffAccess = administrator || access?.isStaff;
+  const disableStartButton = !hasStaffAccess && (checkingEnrollment || isEnrolledInLearningPath === false);
   let showStartButton = true;
 
   let accessText = '';
@@ -93,7 +95,7 @@ export const CourseCard = ({
     });
     accessText = <>Access starts on <b>{startDateStr}</b></>;
     buttonText = 'Start';
-    showStartButton = administrator;
+    showStartButton = !course.access?.isTooEarly || hasStaffAccess;
   } else if (endDateObj) {
     const endDateStr = endDateObj.toLocaleString(undefined, {
       month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
@@ -209,6 +211,10 @@ CourseCard.propTypes = {
     hasOptionalCompletion: PropTypes.bool,
     hasUnearnedOptionalCompletion: PropTypes.bool,
     checkingEnrollment: PropTypes.bool,
+    access: PropTypes.shape({
+      isStaff: PropTypes.bool.isRequired,
+      isTooEarly: PropTypes.bool.isRequired,
+    }),
   }).isRequired,
   relatedLearningPaths: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,

--- a/src/learningpath/LearningPathCard.jsx
+++ b/src/learningpath/LearningPathCard.jsx
@@ -71,11 +71,15 @@ const LearningPathCard = ({ learningPath, showFilters = false }) => {
   // Determine access text and override button text based on access dates.
   if (minDate && minDate > currentDate) {
     // Learning path will start in the future.
-    const minDateStr = minDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const minDateStr = minDate.toLocaleString(undefined, {
+      month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+    });
     accessText = <>Access starts on <b>{minDateStr}</b></>;
     buttonText = 'View';
   } else if (maxDate) {
-    const maxDateStr = maxDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const maxDateStr = maxDate.toLocaleString(undefined, {
+      month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+    });
     if (currentDate > maxDate) {
       // Learning path has ended.
       accessText = <>Access ended on <b>{maxDateStr}</b></>;

--- a/src/learningpath/data/api.js
+++ b/src/learningpath/data/api.js
@@ -37,6 +37,10 @@ export async function fetchLearnerDashboard() {
       isStarted: courseRun.isStarted,
       isArchived: courseRun.isArchived,
       enrollmentDate: enrollment?.lastEnrolled || null,
+      access: {
+        isStaff: enrollment?.coursewareAccess?.isStaff || false,
+        isTooEarly: enrollment?.coursewareAccess?.isTooEarly || false,
+      },
     };
   }));
 
@@ -48,25 +52,33 @@ export async function fetchLearnerDashboard() {
 }
 
 export async function fetchCourseDetails(courseId) {
-  const response = await getAuthenticatedHttpClient().get(
-    `${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${encodeURIComponent(courseId)}/`,
-  );
-  const { data } = response;
+  try {
+    const { username } = getAuthenticatedUser();
+    const response = await getAuthenticatedHttpClient().get(
+      `${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${encodeURIComponent(courseId)}/?username=${username}`,
+    );
+    const { data } = response;
 
-  return camelCaseObject({
-    id: data.course_id,
-    number: data.number,
-    org: data.org,
-    run: data.id.split(':')[1].split('+')[2],
-    name: data.name,
-    shortDescription: data.short_description,
-    endDate: data.end,
-    startDate: data.start,
-    courseImageAssetPath: data.media.course_image.uri,
-    description: data.overview,
-    selfPaced: data.pacing === 'self',
-    duration: data.effort,
-  });
+    return camelCaseObject({
+      id: data.course_id,
+      number: data.number,
+      org: data.org,
+      run: data.id.split(':')[1].split('+')[2],
+      name: data.name,
+      shortDescription: data.short_description,
+      endDate: data.end,
+      startDate: data.start,
+      courseImageAssetPath: data.media.course_image.uri,
+      description: data.overview,
+      selfPaced: data.pacing === 'self',
+      duration: data.effort,
+    });
+  } catch (error) {
+    if (error.response?.status === 404 || error.response?.status === 403) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export async function fetchAllCourseCompletions() {

--- a/src/learningpath/data/queries.js
+++ b/src/learningpath/data/queries.js
@@ -255,6 +255,9 @@ export const useCoursesByIds = (courseIds) => {
           }
 
           const detail = await api.fetchCourseDetails(courseId);
+          if (!detail) {
+            return null;
+          }
           queryClient.setQueryData(QUERY_KEYS.COURSE_DETAILS(courseId), {
             ...detail,
             type: 'course',
@@ -269,7 +272,7 @@ export const useCoursesByIds = (courseIds) => {
         }),
       );
 
-      return results;
+      return results.filter(Boolean);
     },
     enabled: courseIds && courseIds.length > 0,
   });
@@ -296,6 +299,9 @@ export const useCourseDetail = (courseKey) => {
       const completionsMap = createCompletionsMap(completions);
 
       const detail = await api.fetchCourseDetails(courseKey);
+      if (!detail) {
+        return null;
+      }
       return {
         ...addCompletionStatus(detail, completionsMap, courseKey),
         type: 'course',


### PR DESCRIPTION
BREAKING CHANGE: This requires:
1. Setting `COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'`.
2. Removing the `course_experience.pre_start_access` Waffle flag (if enabled).
3. Setting the `catalog_visibility` in all courses to `about` or `both`.

## How to update catalog visibility for all courses
```python
# IMPORTANT: Run this in the CMS shell.
from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
from openedx.core.lib.courses import get_course_by_id
from xmodule.modulestore.django import modulestore
from xmodule.modulestore import ModuleStoreEnum

keys = CourseOverview.get_all_course_keys()

for key in keys:
    print(key)
    course = get_course_by_id(key)
    course.catalog_visibility = "both"
    modulestore().update_item(course, ModuleStoreEnum.UserID.primitive_command)
 ```